### PR TITLE
Ignore API key file from tutorial

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -1,5 +1,6 @@
 # List of untracked files to ignore
 
+myAPIkey.txt
 *.asv
 *.zip
 *.pyc


### PR DESCRIPTION
Just a one-line change to the `.gitignore`, in case users are following this tutorial in a fork or clone of the repo, say, connected to their account. This should avoid the accidental commit of the user's API key to a public repo.

Notice I made this edit from the GitHub UI, and I think it must've automatically coerced the whitespace at the end of the `.gitignore` as well, so that's why you see two lines changed.